### PR TITLE
Support retrieving the list of all users

### DIFF
--- a/src/main/scala/co/ledger/template/repository/algebra.scala
+++ b/src/main/scala/co/ledger/template/repository/algebra.scala
@@ -5,6 +5,7 @@ import co.ledger.template.model.{User, UserName}
 object algebra {
 
   trait UserRepository[F[_]] {
+    def findAll(): F[List[User]]
     def findUser(username: UserName): F[Option[User]]
     def addUser(user: User): F[Unit]
     def updateUser(user: User): F[Unit]

--- a/src/main/scala/co/ledger/template/service/UserService.scala
+++ b/src/main/scala/co/ledger/template/service/UserService.scala
@@ -1,6 +1,5 @@
 package co.ledger.template.service
 
-import cats.data.EitherT
 import cats.effect.Async
 import cats.syntax.applicativeError._
 import cats.syntax.functor._
@@ -14,8 +13,12 @@ class UserService[F[_]: Async](userRepo: UserRepository[F]) {
       maybeUser.toRight[ApiError](UserNotFound(username))
     }
 
-  def findAll: F[ApiError Either List[User]] =
-    EitherT.rightT(List.empty[User]).value
+  def findAll: F[ApiError Either List[User]] = {
+    userRepo.findAll()
+      .attemptT
+      .leftMap[ApiError](e => OtherError(e.getMessage))
+      .value
+  }
 
   def addUser(user: User): F[ApiError Either Unit] =
     userRepo

--- a/src/test/scala/co/ledger/template/repository/UserRepositorySpec.scala
+++ b/src/test/scala/co/ledger/template/repository/UserRepositorySpec.scala
@@ -36,6 +36,9 @@ class UserRepositorySpec extends RepositorySpec {
     }
   }
 
+  test("find all users query") {
+    check(UserStatement.findAll())
+  }
   test("find user query") {
     check(UserStatement.findUser(users.head.username))
   }

--- a/src/test/scala/co/ledger/template/service/TestUserService.scala
+++ b/src/test/scala/co/ledger/template/service/TestUserService.scala
@@ -10,6 +10,10 @@ object TestUserService {
 
   val testRepo: IO[UserRepository[IO]] = Ref.of[IO, Map[model.UserName, model.User]](TestUsers.users.map(u => (u.username, u)).toMap).map{ state =>
     new UserRepository[IO] {
+      override def findAll(): IO[List[model.User]] = {
+        state.get.map(_.values.toList)
+      }
+
       override def findUser(username: UserName): IO[Option[model.User]] =
         state.get.map(_.get(username))
 

--- a/src/test/scala/co/ledger/template/service/UserServiceSpec.scala
+++ b/src/test/scala/co/ledger/template/service/UserServiceSpec.scala
@@ -9,6 +9,12 @@ import co.ledger.template.model.{UserName, UserNotFound}
 
 class UserServiceSpec extends AnyFlatSpecLike with Matchers {
 
+  it should "retrieve all users" in IOAssertion {
+    EitherT(TestUserService.service.flatMap(_.findAll)).map { allUsers =>
+      allUsers should be (users)
+    }.value
+  }
+
   it should "retrieve an user" in IOAssertion {
     EitherT(TestUserService.service.flatMap(_.findUser(users.head.username))).map { user =>
       user should be (users.head)


### PR DESCRIPTION
Add a `findAll()` function to the `UserRepository`.

Return an empty list if there are no users.